### PR TITLE
Fix text-muted-foreground contrast to meet WCAG AA minimum

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -18,7 +18,7 @@
     --secondary: oklch(0.94 0.015 85); /* warmer cream for code blocks - less grey */
     --secondary-foreground: oklch(0.205 0 0);
     --muted: oklch(0.95 0.003 85);
-    --muted-foreground: oklch(0.556 0.02 85);
+    --muted-foreground: oklch(0.538 0.02 85);
     --accent: oklch(0.95 0.003 85);
     --accent-foreground: oklch(0.205 0 0);
     --destructive: oklch(0.58 0.22 27);


### PR DESCRIPTION
Light mode --muted-foreground was oklch(0.556 0.02 85), giving ~4.19:1
contrast against the warm cream background — below the 4.5:1 AA threshold.
Darkening L from 0.556 to 0.538 brings it to ~4.52:1, right at the limit
while preserving the warm muted character.

https://claude.ai/code/session_01JvQt8qTMfYGTWwWtTsb5sz